### PR TITLE
pico_unit: Added a function to provide a return value for the main function.

### DIFF
--- a/pico_unit.h
+++ b/pico_unit.h
@@ -155,6 +155,13 @@ void pu_display_time(bool enabled);
  */
 void pu_print_stats(void);
 
+/**
+ * @brief Fetch a return value for the main function.
+ * 
+ * @return 0 if no test failed, -1 otherwise.
+ */
+int pu_get_result(void);
+
 /*
  * WARNING: These functions are not meant to be called directly. Use the macros
  * instead.
@@ -234,6 +241,12 @@ void
 pu_display_time (bool enabled)
 {
     pu_time = enabled;
+}
+
+int 
+pu_get_result(void)
+{
+    return pu_num_failed == 0 ? 0 : -1;
 }
 
 bool

--- a/pico_unit.h
+++ b/pico_unit.h
@@ -156,11 +156,11 @@ void pu_display_time(bool enabled);
 void pu_print_stats(void);
 
 /**
- * @brief Fetch a return value for the main function.
+ * @brief Check whether at least one test failed.
  * 
- * @return 0 if no test failed, -1 otherwise.
+ * @return true if any test failed, false if they all passed
  */
-int pu_get_result(void);
+bool pu_test_failed(void);
 
 /*
  * WARNING: These functions are not meant to be called directly. Use the macros
@@ -243,10 +243,10 @@ pu_display_time (bool enabled)
     pu_time = enabled;
 }
 
-int 
-pu_get_result(void)
+bool 
+pu_test_failed(void)
 {
-    return pu_num_failed == 0 ? 0 : -1;
+    return (pu_num_failed != 0);
 }
 
 bool

--- a/tests_pico_ecs/main.c
+++ b/tests_pico_ecs/main.c
@@ -481,5 +481,5 @@ int main ()
     pu_setup(setup, teardown);
     PU_RUN_SUITE(suite_ecs);
     pu_print_stats();
-    return pu_get_result();
+    return pu_test_failed();
 }

--- a/tests_pico_ecs/main.c
+++ b/tests_pico_ecs/main.c
@@ -481,5 +481,5 @@ int main ()
     pu_setup(setup, teardown);
     PU_RUN_SUITE(suite_ecs);
     pu_print_stats();
-    return pu_num_failed == 0 ? 0 : -1;
+    return pu_get_result();
 }

--- a/tests_pico_math/main.c
+++ b/tests_pico_math/main.c
@@ -22,5 +22,5 @@ int main()
 
     pu_print_stats();
 
-    return pu_get_result();
+    return pu_test_failed();
 }

--- a/tests_pico_math/main.c
+++ b/tests_pico_math/main.c
@@ -22,5 +22,5 @@ int main()
 
     pu_print_stats();
 
-    return pu_num_failed == 0 ? 0 : -1;
+    return pu_get_result();
 }

--- a/tests_pico_time/main.c
+++ b/tests_pico_time/main.c
@@ -66,5 +66,5 @@ int main (int argc, char* argv[])
     PU_RUN_TEST(test_sec);
     pu_print_stats();
 
-    return pu_get_result();
+    return pu_test_failed();
 }

--- a/tests_pico_time/main.c
+++ b/tests_pico_time/main.c
@@ -66,5 +66,5 @@ int main (int argc, char* argv[])
     PU_RUN_TEST(test_sec);
     pu_print_stats();
 
-    return pu_num_failed == 0 ? 0 : -1;
+    return pu_get_result();
 }


### PR DESCRIPTION
This PR adds a new function `int pu_get_result(void)`to `pico_unit.h`.

The reasoning behind this addition is that:
- The user may want to know if a test failed in an automated system (CI, etc)
- The user may not define `PU_IMPLEMENTATION` in the same file that defines the main function

This new function can simply be called on the return statement of your main function, independently of where the `PU_IMPLEMENTATION` is defined.

Additionally, the return value of current tests has been updated to use this new function.