### PR TITLE
pico_qt.h - Memory + multithreading optimizations

### DIFF
--- a/pico_qt.h
+++ b/pico_qt.h
@@ -225,7 +225,6 @@ void qt_clean(qt_t* qt);
     #define PICO_QT_MEMCPY memcpy
 #endif
 
-
 #ifndef PICO_QT_MEMSET
     #include <string.h>
     #define PICO_QT_MEMSET memset
@@ -372,6 +371,11 @@ void qt_destroy(qt_t* qt)
     QT_ASSERT(qt);
 
     qt_node_destroy(qt, qt->root);
+    for (int i = 0; i < qt_array_size(qt->arena.blocks); ++i)
+    {
+        QT_FREE(qt->arena.blocks[i]);
+    }
+    qt_array_destroy(qt->arena.blocks);
     QT_FREE(qt);
 }
 
@@ -540,6 +544,7 @@ static qt_node_t* qt_node_create(qt_t* qt, qt_rect_t bounds, int depth, int max_
             node->next = qt->arena.free_list;
             qt->arena.free_list = node;
         }
+        qt_array_push(qt->arena.blocks, nodes);
     }
 
     // Pop a node off of the free list.

--- a/pico_qt.h
+++ b/pico_qt.h
@@ -39,7 +39,6 @@
 
     Usage:
     ------
-
     To use this library in your project, add the following
 
     > #define PICO_QT_IMPLEMENTATION
@@ -47,12 +46,21 @@
 
     to a source file (once), then simply include the header normally.
 
-    Constants:
-    --------
-    - PICO_QT_NODE_CAPACITY (default: 16)
-    - PICO_QT_QUERY_CAPACITY (default: 256)
-
     Must be defined before PICO_QT_IMPLEMENTATION
+
+    Customization:
+    --------------
+    A few macros can be overridden simply by defining them before including this
+    source file. Here is a list of them.
+
+    PICO_QT_USE_DOUBLE
+    PICO_QT_USE_UINTPTR
+    PICO_QT_ASSERT
+    PICO_QT_MALLOC
+    PICO_QT_REALLOC
+    PICO_QT_FREE
+    PICO_QT_MEMCPY
+    PICO_QT_MEMSET
 */
 
 #ifndef PICO_QT_H

--- a/pico_qt.h
+++ b/pico_qt.h
@@ -220,28 +220,27 @@ void qt_clean(qt_t* qt);
 #define PICO_QT_FREE(ptr)          (free(ptr))
 #endif
 
-
-// Minimum capacity of array containing node items
-#ifndef PICO_QT_NODE_CAPACITY
-#define PICO_QT_NODE_CAPACITY 16
+#ifndef PICO_QT_MEMCPY
+    #include <string.h>
+    #define PICO_QT_MEMCPY memcpy
 #endif
 
-// Minimum capacity of quadtree's internal array
-#ifndef PICO_QT_QUERY_CAPACITY
-#define PICO_QT_QUERY_CAPACITY 256
+
+#ifndef PICO_QT_MEMSET
+    #include <string.h>
+    #define PICO_QT_MEMSET memset
 #endif
 
 /*=============================================================================
  * Internal aliases
  *============================================================================*/
 
-#define QT_ASSERT        PICO_QT_ASSERT
-#define QT_MALLOC        PICO_QT_MALLOC
-#define QT_REALLOC       PICO_QT_REALLOC
-#define QT_FREE          PICO_QT_FREE
-#define QT_MAX_DEPTH     PICO_QT_MAX_DEPTH
-#define QT_NODE_CAPACITY PICO_QT_NODE_CAPACITY
-#define QT_QUERY_CAPACITY  PICO_QT_QUERY_CAPACITY
+#define QT_ASSERT         PICO_QT_ASSERT
+#define QT_MEMCPY         PICO_QT_MEMCPY
+#define QT_MEMSET         PICO_QT_MEMSET
+#define QT_MALLOC         PICO_QT_MALLOC
+#define QT_REALLOC        PICO_QT_REALLOC
+#define QT_FREE           PICO_QT_FREE
 
 /*=============================================================================
  * Internal data structures
@@ -249,18 +248,55 @@ void qt_clean(qt_t* qt);
 
 typedef struct qt_node_t qt_node_t;
 
-typedef struct
+typedef struct qt_array_header_t
 {
-    qt_value_t value;
-    qt_rect_t  bounds;
-} qt_item_t;
+    int capacity;
+    int size;
+    char* data;
+    uint32_t cookie;
+} qt_array_header_t;
 
-typedef struct
-{
-    int        capacity;
-    int        size;
-    qt_item_t* items;
-} qt_array_t;
+// An optional empty macro used to markup dynamic arrays. This is useful to help remind
+// us that a particular pointer is a dynamic array, and not merely a pointer.
+#define qt_array
+
+// Fetches the header `qt_array_header_t` of a dynamic array.
+#define qt_hdr(a) ((qt_array_header_t*)a - 1)
+
+// Helper to assert this pointer is indeed a dynamic array.
+// Like a "canary in the coal mine".
+#define QT_ARRAY_CANARY(a) ((a) ? QT_ASSERT(qt_hdr(a)->cookie == QT_ARRAY_COOKIE) : (void)0)
+
+// A magic number for `QT_ARRAY_CANARY`.
+#define QT_ARRAY_COOKIE 0xE6F7E359
+
+// Returns the number of elements in the array.
+// This is a proper l-value, so you can do e.g. qt_array_size(a)--
+#define qt_array_len(a) (qt_hdr(a)->size)
+
+// Returns the number of elements in the array.
+// Passing in NULL will return 0.
+#define qt_array_size(a) (QT_ARRAY_CANARY(a), a ? qt_hdr(a)->size : 0)
+
+// Returns the capacity of the array.
+#define qt_array_capacity(a) (QT_ARRAY_CANARY(a), (a) ? qt_hdr(a)->capacity : 0)
+
+// Makes sure the capacity of the array can fit `n` elements.
+#define qt_array_fit(a, n) ((n) <= qt_array_capacity(a) ? 0 : (*(void**)&(a) = qt_array_fit_impl((a), (n), sizeof(*a))))
+
+// Pushes an element onto the array. Will resize itself as necessary.
+#define qt_array_push(a, ...) (QT_ARRAY_CANARY(a), qt_array_fit((a), 1 + ((a) ? qt_array_size(a) : 0)), (a)[qt_array_len(a)++] = (__VA_ARGS__))
+
+// Clears the array.
+#define qt_array_clear(a) (QT_ARRAY_CANARY(a), a ? (void)(qt_array_len(a) = 0) : (void)0)
+
+// Free's up a dynamic array.
+#define qt_array_destroy(a) (QT_ARRAY_CANARY(a), a ? QT_FREE(qt_hdr(a)) : (void)0, a = NULL)
+
+// Overwrites the item at the index with the item at the end of the array.
+// This is fast, but it changes the order of the array Fortunately, order
+// doesn't matter in this case.
+#define qt_array_remove(a, i) (QT_ARRAY_CANARY(a), a[i] = a[--qt_array_len(a)])
 
 struct qt_node_t
 {
@@ -268,34 +304,49 @@ struct qt_node_t
     int        max_depth;
     qt_rect_t  bounds[4];
     qt_node_t* nodes[4];
-    qt_array_t items;
+    qt_array qt_value_t* values;
+    qt_array qt_rect_t*  rects;
 };
+
+typedef struct qt_free_node_t
+{
+    struct qt_free_node_t* next;
+} qt_free_node_t;
+
+typedef struct qt_node_allocator_t
+{
+    qt_free_node_t* free_list;
+    qt_array qt_node_t** blocks;
+} qt_node_allocator_t;
 
 struct qt_t
 {
-    qt_array_t query;
     qt_rect_t  bounds;
     qt_node_t* root;
+
+    // A custom allocator is used here to allocate individual nodes.
+    // This attempts to pack all the nodes together in memory to try and
+    // keep them in similar cache lines. This is slightly superior to calling
+    // `QT_MALLOC` once per node, where traversing the tree (if cold and not
+    // currently in the CPU cache) would incur a cache miss for every single
+    // node no matter what.
+    qt_node_allocator_t arena;
 };
 
 /*=============================================================================
  * Internal function declarations
  *============================================================================*/
 
-static void qt_array_init(qt_array_t* array, int capacity);
-static void qt_array_destroy(qt_array_t* array);
-static void qt_array_resize(qt_array_t* array, int size);
-static void qt_array_push(qt_array_t* array, const qt_rect_t* bounds, qt_value_t value);
-static void qt_array_cat(qt_array_t* dst, const qt_array_t* src);
-static void qt_array_remove(qt_array_t* array, int index);
+static void* qt_array_fit_impl(const void* array, int new_size, size_t element_size);
 static bool qt_rect_contains(const qt_rect_t* r1, const qt_rect_t* r2);
 static bool qt_rect_overlaps(const qt_rect_t* r1, const qt_rect_t* r2);
-static qt_node_t* qt_node_create(qt_rect_t bounds, int depth, int max_depth);
-static void qt_node_destroy(qt_node_t* node);
-static void qt_node_insert(qt_node_t* node, const qt_rect_t* bounds, qt_value_t value);
+static qt_node_t* qt_node_create(qt_t* qt, qt_rect_t bounds, int depth, int max_depth);
+static void qt_node_destroy(qt_t* qt, qt_node_t* node);
+static void qt_node_insert(qt_t* qt, qt_node_t* node, const qt_rect_t* bounds, qt_value_t value);
 static bool qt_node_remove(qt_node_t* node, qt_value_t value);
-static void qt_node_all_items(const qt_node_t* node, qt_array_t* array);
-static void qt_node_query(const qt_node_t* node, const qt_rect_t* area, qt_array_t* array);
+static qt_array qt_rect_t* qt_node_all_rects(const qt_node_t* node, qt_array qt_rect_t* rects);
+static qt_array qt_value_t* qt_node_all_values(const qt_node_t* node, qt_array qt_value_t* values);
+static qt_array qt_value_t* qt_node_query(const qt_node_t* node, const qt_rect_t* area, qt_array qt_value_t* values);
 static void qt_node_clear(qt_node_t* node);
 
 /*=============================================================================
@@ -304,15 +355,14 @@ static void qt_node_clear(qt_node_t* node);
 
 qt_t* qt_create(qt_rect_t bounds, int max_depth)
 {
-    qt_t* qt = QT_MALLOC(sizeof(qt_t));
+    qt_t* qt = (qt_t*)QT_MALLOC(sizeof(qt_t));
+    QT_MEMSET(qt, 0, sizeof(*qt));
 
     if (!qt)
         return NULL;
 
     qt->bounds = bounds;
-    qt->root = qt_node_create(bounds, 0, max_depth);
-
-    qt_array_init(&qt->query, QT_QUERY_CAPACITY);
+    qt->root = qt_node_create(qt, bounds, 0, max_depth);
 
     return qt;
 }
@@ -321,8 +371,7 @@ void qt_destroy(qt_t* qt)
 {
     QT_ASSERT(qt);
 
-    qt_array_destroy(&qt->query);
-    qt_node_destroy(qt->root);
+    qt_node_destroy(qt, qt->root);
     QT_FREE(qt);
 }
 
@@ -332,15 +381,15 @@ void qt_reset(qt_t* qt)
 
     int max_depth = qt->root->max_depth;
 
-    qt_node_destroy(qt->root);
+    qt_node_destroy(qt, qt->root);
 
-    qt->root = qt_node_create(qt->bounds, 0, max_depth);
+    qt->root = qt_node_create(qt, qt->bounds, 0, max_depth);
 }
 
 void qt_insert(qt_t* qt, qt_rect_t bounds, qt_value_t value)
 {
     QT_ASSERT(qt);
-    qt_node_insert(qt->root, &bounds, value);
+    qt_node_insert(qt, qt->root, &bounds, value);
 }
 
 bool qt_remove(qt_t* qt, qt_value_t value)
@@ -358,30 +407,18 @@ qt_value_t* qt_query(qt_t* qt, qt_rect_t area, int* size)
     if (!size)
         return NULL;
 
-    // Reset the internal array
-    qt->query.size = 0;
-
     // Start query the root node
-    qt_node_query(qt->root, &area, &qt->query);
+    qt_array qt_value_t* values = qt_node_query(qt->root, &area, NULL);
 
     // If no results then return NULL
-    if (qt->query.size == 0)
+    if (!values)
     {
         *size = 0;
         return NULL;
     }
 
-    // Allocate value array
-    qt_value_t* values = QT_MALLOC(qt->query.size * sizeof(qt_value_t));
-
-    // Fill value array
-    for (int i = 0; i < qt->query.size; i++)
-    {
-        values[i] = qt->query.items[i].value;
-    }
-
     // Set size and return
-    *size = qt->query.size;
+    *size = qt_array_size(values);
 
     return values;
 }
@@ -391,7 +428,7 @@ void qt_free(qt_value_t* array)
     if (!array)
         return;
 
-    QT_FREE(array);
+    qt_array_destroy(array);
 }
 
 void qt_clear(qt_t* qt)
@@ -404,122 +441,63 @@ void qt_clean(qt_t* qt)
 {
     QT_ASSERT(qt);
 
-    qt_array_t array;
-    qt_array_init(&array, QT_QUERY_CAPACITY);
-
-    qt_node_all_items(qt->root, &array);
+    qt_array qt_rect_t* rects = qt_node_all_rects(qt->root, NULL);
+    qt_array qt_value_t* values = qt_node_all_values(qt->root, NULL);
+    QT_ASSERT(qt_array_size(rects) == qt_array_size(values));
     qt_reset(qt);
 
-    for (int i = 0; i < array.size; i++)
+    for (int i = 0; i < qt_array_size(rects); i++)
     {
-        qt_item_t* item = &array.items[i];
-        qt_insert(qt, item->bounds, item->value);
+        qt_insert(qt, rects[i], values[i]);
     }
 
-    qt_array_destroy(&array);
+    qt_array_destroy(rects);
+    qt_array_destroy(values);
 }
 
 /*=============================================================================
  * Internal function definitions
  *============================================================================*/
 
-static void qt_array_init(qt_array_t* array, int capacity)
+static int qt_max(int a, int b)
 {
-    QT_ASSERT(array);
+    return a > b ? a : b;
+}
 
-    array->size = 0;
-    array->capacity = capacity;
+// Don't call this directly -- use `qt_array_fit` instead.
+static void* qt_array_fit_impl(const void* array, int new_size, size_t element_size)
+{
+    QT_ARRAY_CANARY(array);
 
-    if (capacity > 0)
-        array->items = QT_MALLOC(capacity * sizeof(qt_item_t));
+    // Double the old capacity, or pick at least 16 for the starting size.
+    // This helps unnecessarily numerous realloc's for low capacities when starting out.
+    int new_capacity = qt_max(2 * qt_array_capacity(array), qt_max(new_size, 16));
+    QT_ASSERT(new_size <= new_capacity);
+
+    // Total size of the header struct `qt_array_header_t` along with the size of all
+    // elements packed together in a single allocation.
+    size_t total_size = sizeof(qt_array_header_t) + new_capacity * element_size;
+    qt_array_header_t* hdr;
+
+    if (array)
+    {
+        // Realloc of the header isn't new.
+        // This expands the capacity.
+        hdr = (qt_array_header_t*)QT_REALLOC(qt_hdr(array), total_size);
+    }
+
     else
-        array->items = NULL;
-}
-
-static void qt_array_destroy(qt_array_t* array)
-{
-    QT_ASSERT(array);
-    QT_FREE(array->items);
-
-    array->items = NULL;
-    array->capacity = 0;
-    array->size = 0;
-}
-
-static void qt_array_resize(qt_array_t* array, int size)
-{
-    QT_ASSERT(array);
-
-    // No change if size is below the capacity
-    if (size < array->capacity)
     {
-        array->size = size;
-        return;
+        // Create a new array if the pointer passed in was NULL, as NULL means an empty array.
+        hdr = (qt_array_header_t*)QT_MALLOC(total_size);
+        hdr->size = 0;
     }
 
-    // Calculate new capacity
-    while (array->capacity <= size)
-    {
-        array->capacity += (array->capacity / 2) + 2;
-    }
+    hdr->cookie = QT_ARRAY_COOKIE; // For sanity checks with `QT_ARRAY_CANARY`.
+    hdr->capacity = new_capacity;
+    hdr->data = (char*)(hdr + 1); // For debugging convenience.
 
-    // Reallocate the array and set the new size
-    array->items = QT_REALLOC(array->items, array->capacity * sizeof(qt_item_t));
-    array->size = size;
-}
-
-static void qt_array_push(qt_array_t* array, const qt_rect_t* bounds, qt_value_t value)
-{
-    QT_ASSERT(array);
-    QT_ASSERT(bounds);
-
-    int size = array->size;
-
-    // Resize the array by one
-    qt_array_resize(array, size + 1);
-
-    // Store new item
-    array->items[size].value  =  value;
-    array->items[size].bounds = *bounds;
-}
-
-static void qt_array_cat(qt_array_t* dst, const qt_array_t* src)
-{
-    QT_ASSERT(dst);
-    QT_ASSERT(src);
-
-    int total_capacity = dst->capacity + src->capacity;
-
-    // Resize the array if dst capacity is less than the sum of the capacities
-    // This is the most likely case
-    if (dst->capacity < total_capacity)
-    {
-        dst->items = QT_REALLOC(dst->items, total_capacity * sizeof(qt_item_t));
-        dst->capacity = total_capacity;
-    }
-
-    // Copy the contents of the src array onto the end of the dst array
-    memcpy(&dst->items[dst->size], src->items, src->size * sizeof(qt_item_t));
-
-    // Increase the size to match
-    dst->size += src->size;
-}
-
-static void qt_array_remove(qt_array_t* array, int index)
-{
-    QT_ASSERT(array);
-    QT_ASSERT(index < array->size);
-
-    int size = array->size;
-
-    // Overwrites the item at the index with the item at the end of the array
-    // This is fast, but it changes the order of the array Fortunately, order
-    // doesn't matter in this case
-    if (size > 0)
-    {
-        array->items[index] = array->items[size - 1];
-        array->size--;
-    }
+    return (void*)(hdr + 1);
 }
 
 qt_rect_t qt_make_rect(qt_float x, qt_float y, qt_float w, qt_float h)
@@ -549,11 +527,25 @@ static bool qt_rect_overlaps(const qt_rect_t* r1, const qt_rect_t* r2)
            r2->y + r2->h >= r1->y;
 }
 
-static qt_node_t* qt_node_create(qt_rect_t bounds, int depth, int  max_depth)
+static qt_node_t* qt_node_create(qt_t* qt, qt_rect_t bounds, int depth, int max_depth)
 {
-    qt_node_t* node = QT_MALLOC(sizeof(qt_node_t));
+    if (!qt->arena.free_list)
+    {
+        // Allocate space for more nodes and add them to the free list.
+        const int block_count = 128;
+        qt_node_t* nodes = (qt_node_t*)QT_MALLOC(sizeof(qt_node_t) * block_count);
+        for (int i = 0; i < block_count; ++i)
+        {
+            qt_free_node_t* node = (qt_free_node_t*)(nodes + i);
+            node->next = qt->arena.free_list;
+            qt->arena.free_list = node;
+        }
+    }
 
-    memset(node, 0, sizeof(qt_node_t));
+    // Pop a node off of the free list.
+    qt_node_t* node = (qt_node_t*)qt->arena.free_list;
+    qt->arena.free_list = qt->arena.free_list->next;
+    QT_MEMSET(node, 0, sizeof(qt_node_t));
 
     node->depth = depth;
     node->max_depth = max_depth;
@@ -583,34 +575,33 @@ static qt_node_t* qt_node_create(qt_rect_t bounds, int depth, int  max_depth)
                                    bounds.w,
                                    bounds.h);
 
-    // Initialize item array with default capacity
-    qt_array_init(&node->items, QT_NODE_CAPACITY);
-
     return node;
 }
 
-static void qt_node_destroy(qt_node_t* node)
+static void qt_node_destroy(qt_t* qt, qt_node_t* node)
 {
     QT_ASSERT(node);
+    
+    qt_array_destroy(node->values);
+    qt_array_destroy(node->rects);
 
     // Recursively destroy nodes
     for (int i = 0; i < 4; i++)
     {
         if (node->nodes[i])
-            qt_node_destroy(node->nodes[i]);
+            qt_node_destroy(qt, node->nodes[i]);
     }
 
-    // Deallocate item array
-    qt_array_destroy(&node->items);
-
-    // Free current node
-    QT_FREE(node);
+    // Free current node by pushing it onto the free list
+    qt_free_node_t* free_node = (qt_free_node_t*)node;
+    free_node->next = qt->arena.free_list;
+    qt->arena.free_list = free_node;
 }
 
-static void qt_node_insert(qt_node_t* node, const qt_rect_t* bounds, qt_value_t value)
+static void qt_node_insert(qt_t* qt, qt_node_t* node, const qt_rect_t* rect, qt_value_t value)
 {
     QT_ASSERT(node);
-    QT_ASSERT(bounds);
+    QT_ASSERT(rect);
 
     // The purpose of this function is to optimally fit the item into a subtree.
     // This occurs when the item is no longer fully contained within a subtree,
@@ -624,18 +615,19 @@ static void qt_node_insert(qt_node_t* node, const qt_rect_t* bounds, qt_value_t 
         for (int i = 0; i < 4; i++)
         {
             // Check if subtree contains the bounds
-            if (qt_rect_contains(&node->bounds[i], bounds))
+            if (qt_rect_contains(&node->bounds[i], rect))
             {
                 // If child node does not exist, then create it
                 if (!node->nodes[i])
                 {
-                    node->nodes[i] = qt_node_create(node->bounds[i],
+                    node->nodes[i] = qt_node_create(qt,
+                                                    node->bounds[i],
                                                     node->depth + 1,
                                                     node->max_depth);
                 }
 
                 // Recursively try to insert the item into the subtree
-                qt_node_insert(node->nodes[i], bounds, value);
+                qt_node_insert(qt, node->nodes[i], rect, value);
                 return;
             }
         }
@@ -643,7 +635,8 @@ static void qt_node_insert(qt_node_t* node, const qt_rect_t* bounds, qt_value_t 
 
     // If none of the children fully contain the bounds, or the maximum depth
     // has been reached, then the item belongs to this node
-    qt_array_push(&node->items, bounds, value);
+    qt_array_push(node->rects, *rect);
+    qt_array_push(node->values, value);
 }
 
 static bool qt_node_remove(qt_node_t* node, qt_value_t value)
@@ -652,14 +645,13 @@ static bool qt_node_remove(qt_node_t* node, qt_value_t value)
 
     // Searches the items in this node and, if found, removes the item with the
     // specified value
-    for (int i = 0; i < node->items.size; i++)
+    for (int i = 0; i < qt_array_size(node->rects); i++)
     {
-        qt_item_t* item = &node->items.items[i];
-
-        // If value is found, then remove the node from the items array
-        if (item->value == value)
+        // If value is found, then remove it and it's bounds from the node
+        if (node->values[i] == value)
         {
-            qt_array_remove(&node->items, i);
+            qt_array_remove(node->rects, i);
+            qt_array_remove(node->values, i);
             return true;
         }
     }
@@ -678,36 +670,59 @@ static bool qt_node_remove(qt_node_t* node, qt_value_t value)
     return false;
 }
 
-static void qt_node_all_items(const qt_node_t* node, qt_array_t* array)
+static qt_array qt_rect_t* qt_node_all_rects(const qt_node_t* node, qt_array qt_rect_t* rects)
 {
     QT_ASSERT(node);
-    QT_ASSERT(array);
 
-    // Add all items in this node into the array
-    qt_array_cat(array, &node->items);
+    // Add all values in this node into the array
+    for (int i = 0; i < qt_array_size(node->rects); ++i)
+    {
+        qt_array_push(rects, node->rects[i]);
+    }
 
-    // Recursively add all items found in the subtrees
+    // Recursively add all values found in the subtrees
     for (int i = 0; i < 4; i++)
     {
         if (node->nodes[i])
-            qt_node_all_items(node->nodes[i], array);
+            rects = qt_node_all_rects(node->nodes[i], rects);
     }
+
+    return rects;
 }
 
-static void qt_node_query(const qt_node_t* node, const qt_rect_t* area, qt_array_t* array)
+static qt_array qt_value_t* qt_node_all_values(const qt_node_t* node, qt_array qt_value_t* values)
+{
+    QT_ASSERT(node);
+
+    // Add all values in this node into the array
+    for (int i = 0; i < qt_array_size(node->values); ++i)
+    {
+        qt_array_push(values, node->values[i]);
+    }
+
+    // Recursively add all values found in the subtrees
+    for (int i = 0; i < 4; i++)
+    {
+        if (node->nodes[i])
+            values = qt_node_all_values(node->nodes[i], values);
+    }
+
+    return values;
+}
+
+static qt_array qt_value_t* qt_node_query(const qt_node_t* node, const qt_rect_t* area, qt_array qt_value_t* values)
 {
     QT_ASSERT(node);
     QT_ASSERT(area);
-    QT_ASSERT(array);
 
     // Searches for items in this node that intersect the area and adds them to
     // the array
-    for (int i = 0; i < node->items.size; i++)
+    for (int i = 0; i < qt_array_size(node->rects); i++)
     {
-        qt_item_t* item = &node->items.items[i];
+        const qt_rect_t* rect = &node->rects[i];
 
-        if (qt_rect_overlaps(area, &item->bounds))
-            qt_array_push(array, &item->bounds, item->value);
+        if (qt_rect_overlaps(area, rect))
+            qt_array_push(values, node->values[i]);
     }
 
     // Loop over subtrees
@@ -719,7 +734,7 @@ static void qt_node_query(const qt_node_t* node, const qt_rect_t* area, qt_array
             // subtree match and are recursively added to the array
             if (qt_rect_contains(area, &node->bounds[i]))
             {
-                qt_node_all_items(node->nodes[i], array);
+                values = qt_node_all_values(node->nodes[i], values);
             }
             else
             {
@@ -728,16 +743,19 @@ static void qt_node_query(const qt_node_t* node, const qt_rect_t* area, qt_array
                 // or contained within the area
                 if (qt_rect_overlaps(area, &node->bounds[i]))
                 {
-                    qt_node_query(node->nodes[i], area, array);
+                    values = qt_node_query(node->nodes[i], area, values);
                 }
             }
         }
     }
+
+    return values;
 }
 
 static void qt_node_clear(qt_node_t* node)
 {
-    node->items.size = 0;
+    qt_array_clear(node->rects);
+    qt_array_clear(node->values);
 
     for (int i = 0; i < 4; i++)
     {

--- a/pico_unit.h
+++ b/pico_unit.h
@@ -75,7 +75,7 @@ extern "C" {
  *
  * @param name The name of the test. Must be a valid C function name
  */
-#define TEST_CASE(name) static bool name()
+#define TEST_CASE(name) static bool name(void)
 
 /**
  * @brief Asserts that a condition is true
@@ -107,7 +107,7 @@ extern "C" {
  *
  * @param name The name of the test suite
  */
-#define TEST_SUITE(name) void name()
+#define TEST_SUITE(name) void name(void)
 
 /**
  * @brief Runs a series of unit tests. The test suite function has the signature,

--- a/tests_pico_qt/main.c
+++ b/tests_pico_qt/main.c
@@ -35,6 +35,8 @@ TEST_CASE(test_insert_single)
 
         REQUIRE(size == 0);
         REQUIRE(values == NULL);
+
+        qt_free(values);
     }
 
     return true;
@@ -52,6 +54,8 @@ TEST_CASE(test_insert_single_contained)
 
         REQUIRE(size == 1);
         REQUIRE(values[0] == 0);
+
+        qt_free(values);
     }
 
     // Not found
@@ -60,6 +64,8 @@ TEST_CASE(test_insert_single_contained)
 
         REQUIRE(size == 0);
         REQUIRE(values == NULL);
+
+        qt_free(values);
     }
 
     return true;
@@ -83,6 +89,8 @@ TEST_CASE(test_insert_multiple)
     REQUIRE(values[0] == 0);
     REQUIRE(values[1] == 1);
     REQUIRE(values[2] == 2);
+
+    qt_free(values);
 
     return true;
 }
@@ -112,6 +120,8 @@ TEST_CASE(test_insert_multiple_random)
     {
         REQUIRE(values[i] == (qt_value_t)i);
     }
+
+    qt_free(values);
 
     return true;
 }
@@ -153,6 +163,8 @@ TEST_CASE(test_insert_multiple_random_contained)
 
         REQUIRE(size == 0);
         REQUIRE(values == NULL);
+
+        qt_free(values);
     }
 
     return true;
@@ -182,6 +194,8 @@ TEST_CASE(test_remove)
 
     REQUIRE(size == 0);
     REQUIRE(values == NULL);
+
+    qt_free(values);
 
     return true;
 }
@@ -214,6 +228,8 @@ TEST_CASE(test_reset)
     REQUIRE(size == 0);
     REQUIRE(values == NULL);
 
+    qt_free(values);
+
     return true;
 }
 
@@ -245,6 +261,8 @@ TEST_CASE(test_clear)
     REQUIRE(size == 0);
     REQUIRE(values == NULL);
 
+    qt_free(values);
+
     return true;
 }
 
@@ -275,6 +293,8 @@ TEST_CASE(test_clean)
 
     REQUIRE(size == 32);
 
+    qt_free(values);
+
     return true;
 }
 
@@ -291,16 +311,14 @@ static TEST_SUITE(suite_qt)
     RUN_TEST_CASE(test_clean);
 }
 
-void setup()
+void setup(void)
 {
     qt = qt_create(qt_make_rect(-10, -10, 20, 20), 6);
-    values = NULL;
 }
 
-void teardown()
+void teardown(void)
 {
     qt_destroy(qt);
-    qt_free(values);
     qt = NULL;
 }
 
@@ -315,7 +333,7 @@ int main()
 
 static int cmp_values(const void * a, const void * b)
 {
-   return ( *(qt_value_t*)a - *(qt_value_t*)b );
+   return (int)( *(qt_value_t*)a - *(qt_value_t*)b );
 }
 
 static void sort_values(qt_value_t* values, int size)


### PR DESCRIPTION
Thanks so much for making and sharing this really cool header! I think your code here is really high quality. I've made an attempt at some memory/multithreading related optimizations. These are in preparation to add an API set for serializing the tree to memory (and packing all the nodes together in a decent sorted order for tree traversals). Please let me know if you have any feedback at all! Here's the description of the changes here.

1. `QT_MAX_DEPTH` and `PICO_QT_MAX_DEPTH` aren't used, so they were deleted.
2. `PICO_QT_NODE_CAPACITY` and `PICO_QT_QUERY_CAPACITY` were removed in favor of streamlining creating dynamic arrays (more on this in the next point).
3. The array query function `qt_query` was not thread safe. After modifying it to be thread-safe, I noticed it was performing an extra malloc and copy operation to collate user values into a single array. Instead, I decided to implement a dynamic c-array using [STB's stretchy buffer](https://nothings.org/stb/stretchy_buffer.txt) array style. This uses some polymorphic macros. This way multiple kinds of arrays can be created without any code duplication. I split the node's `items` array into two separate arrays called `values` and `rects`. During a query, a single array of `qt_value_t` is collated and returned. This is thread-safe since no static memory local the tree is used, and no extra array-copy is necessary (achieving the original goal).
4. I noticed malloc was called for every single node created in the tree. This can be optimized a little bit by using a custom allocator for nodes. I used the [arena style allocator](https://www.rfleury.com/p/untangling-lifetimes-the-arena-allocator) since it's so simple and works here. The idea is that a big block of 128 nodes are allocated at a time, and all added onto a singly linked list to represent a list of "free nodes". Allocating a new node now can happen in constant time, without calling malloc much (which in practice means less synchronization overhead, as malloc usually has a mutex underneath). Though, the biggest benefit is that nodes are allocated next to each other in memory, which may reduce the occasional cache miss. This is overall a very minor change. To really get good performance nodes should be sorted in memory next to each other for common traversal -- this is planned for my next PR via serializing the tree (which will include a node-packing implementation).
5. Some overrideable macros like `PICO_QT_MEMCPY` and `PICO_QT_MEMSET` were added.
6. Added `void` to parameter list to silence some warnings compiling with MSVC in pico_unit.h.
7. Updated all unit tests to free the returned query arrays within each test.

I apologize for the large pull request. Originally I just wanted to do number 3, but ran into a few issues when trying to refactor the array memory handling, and well, here we are :D