### PR TITLE
pico_ecs: ecs_add() removes and ecs_remove() adds entities based on exclude

### DIFF
--- a/pico_ecs.h
+++ b/pico_ecs.h
@@ -888,6 +888,21 @@ void* ecs_add(ecs_t* ecs, ecs_id_t entity_id, ecs_id_t comp_id, void* args)
     // Load entity
     ecs_entity_t* entity = &ecs->entities[entity_id];
 
+    // Remove entity from systems
+    for (ecs_id_t sys_id = 0; sys_id < ecs->system_count; sys_id++)
+    {
+        ecs_sys_t* sys = &ecs->systems[sys_id];
+
+        if (ecs_entity_system_test(&sys->require_bits, &sys->exclude_bits, &entity->comp_bits))
+        {
+            if (ecs_sparse_set_remove(&sys->entity_ids, entity_id))
+            {
+                if (sys->remove_cb)
+                    sys->remove_cb(ecs, entity_id, sys->udata);
+            }
+        }
+    }
+
     // Load component
     ecs_array_t* comp_array = &ecs->comp_arrays[comp_id];
     ecs_comp_t* comp = &ecs->comps[comp_id];
@@ -963,6 +978,21 @@ void ecs_remove(ecs_t* ecs, ecs_id_t entity_id, ecs_id_t comp_id)
 
     // Reset the relevant component mask bit
     ecs_bitset_flip(&entity->comp_bits, comp_id, false);
+
+    // Add entity to systems
+    for (ecs_id_t sys_id = 0; sys_id < ecs->system_count; sys_id++)
+    {
+        ecs_sys_t* sys = &ecs->systems[sys_id];
+
+        if (ecs_entity_system_test(&sys->require_bits, &sys->exclude_bits, &entity->comp_bits))
+        {
+            if (ecs_sparse_set_add(ecs, &sys->entity_ids, entity_id))
+            {
+                if (sys->add_cb)
+                    sys->add_cb(ecs, entity_id, sys->udata);
+            }
+        }
+    }
 }
 
 void ecs_queue_destroy(ecs_t* ecs, ecs_id_t entity_id)

--- a/tests_pico_ecs/main.c
+++ b/tests_pico_ecs/main.c
@@ -97,6 +97,22 @@ TEST_CASE(test_exclude)
     REQUIRE(exclude_sys_state.count == 1);
     REQUIRE(exclude_sys_state.eid == eid2);
 
+    // Removing comp1 from entity1 causes it to be added to the system
+    ecs_remove(ecs, eid1, comp1_id);
+
+    ecs_update_system(ecs, system_id, 0.0);
+
+    REQUIRE(exclude_sys_state.count == 2);
+    REQUIRE(exclude_sys_state.eid == eid2);
+
+    // Adding comp1 to entity2 causes it to be removed from the system
+    ecs_add(ecs, eid2, comp1_id, NULL);
+
+    ecs_update_system(ecs, system_id, 0.0);
+
+    REQUIRE(exclude_sys_state.count == 1);
+    REQUIRE(exclude_sys_state.eid == eid1);
+
     return true;
 }
 


### PR DESCRIPTION
I noticed that excluded components for systems wasn't respected by ecs_add()/ecs_remove() when adding and removing components for an entity dynamically.

I updated the test case and duplicated the system updating part from ecs_add() and ecs_remove() to be present in both.