### PR TITLE
Add format attribute to pico_log's log_write

### DIFF
--- a/pico_log.h
+++ b/pico_log.h
@@ -319,6 +319,9 @@ void log_display_function(log_appender_t id, bool enabled);
  * WARNING: It is inadvisable to call this function directly. Use the macros
  * instead.
  */
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((format(printf, 5, 6)))
+#endif
 void log_write(log_level_t level,
                const char* file,
                unsigned line,


### PR DESCRIPTION
On clang and gcc, this will show warning if the vararg does not match the format.