### PR TITLE
pico_ecs: ecs_destroy now uses the entity system test. debugging tests.

### DIFF
--- a/pico_ecs.h
+++ b/pico_ecs.h
@@ -819,9 +819,7 @@ void ecs_destroy(ecs_t* ecs, ecs_id_t entity_id)
     {
         ecs_sys_t* sys = &ecs->systems[sys_id];
 
-        // Just attempting to remove the entity from the sparse set is faster
-        // than calling ecs_entity_system_test
-        if (ecs_bitset_is_zero(&sys->exclude_bits) &&
+        if (ecs_entity_system_test(&sys->require_bits, &sys->exclude_bits, &entity->comp_bits) &&
             ecs_sparse_set_remove(&sys->entity_ids, entity_id))
         {
             if (sys->remove_cb)
@@ -925,7 +923,7 @@ void* ecs_add(ecs_t* ecs, ecs_id_t entity_id, ecs_id_t comp_id, void* args)
         }
         else // Just remove the entity if its components no longer match for whatever reason.
         {
-            if (!ecs_bitset_is_zero(&sys->exclude_bits) && 
+            if (!ecs_bitset_is_zero(&sys->exclude_bits) &&
                  ecs_sparse_set_remove(&sys->entity_ids, entity_id))
             {
                 if (sys->remove_cb)
@@ -968,7 +966,7 @@ void ecs_remove(ecs_t* ecs, ecs_id_t entity_id, ecs_id_t comp_id)
         }
         else
         {
-            if (!ecs_bitset_is_zero(&sys->exclude_bits) && 
+            if (!ecs_bitset_is_zero(&sys->exclude_bits) &&
                  ecs_sparse_set_add(ecs, &sys->entity_ids, entity_id))
             {
                 if (sys->add_cb)
@@ -1329,7 +1327,7 @@ static size_t ecs_sparse_set_find(ecs_sparse_set_t* set, ecs_id_t id)
 {
     ECS_ASSERT(ecs_is_not_null(set));
 
-    if (id < set->capacity && set->sparse[id] < set->size && set->dense[set->sparse[id]] == id)
+    if (set->sparse[id] < set->size && set->dense[set->sparse[id]] == id)
         return set->sparse[id];
     else
         return ECS_NULL;
@@ -1569,4 +1567,3 @@ static bool ecs_is_system_ready(ecs_t* ecs, ecs_id_t sys_id)
 */
 
 // EoF
-

--- a/pico_ecs.h
+++ b/pico_ecs.h
@@ -619,12 +619,6 @@ void ecs_free(ecs_t* ecs)
 {
     ECS_ASSERT(ecs_is_not_null(ecs));
 
-    for (ecs_id_t entity_id = 0; entity_id < ecs->entity_count; entity_id++)
-    {
-        if (ecs->entities[entity_id].ready)
-            ecs_destroy(ecs, entity_id);
-    }
-
     ecs_stack_free(ecs, &ecs->entity_pool);
     ecs_stack_free(ecs, &ecs->destroy_queue);
     ecs_stack_free(ecs, &ecs->remove_queue);
@@ -648,12 +642,6 @@ void ecs_free(ecs_t* ecs)
 void ecs_reset(ecs_t* ecs)
 {
     ECS_ASSERT(ecs_is_not_null(ecs));
-
-    for (ecs_id_t entity_id = 0; entity_id < ecs->entity_count; entity_id++)
-    {
-        if (ecs->entities[entity_id].ready)
-            ecs_destroy(ecs, entity_id);
-    }
 
     ecs->entity_pool.size   = 0;
     ecs->destroy_queue.size = 0;

--- a/tests_pico_ecs/main.c
+++ b/tests_pico_ecs/main.c
@@ -104,18 +104,13 @@ static void exclude_remove_cb(ecs_t* ecs,
     state->remove_count++;
 }
 
+exclude_sys_state_t state1;
+exclude_sys_state_t state2;
+
 TEST_CASE(test_exclude)
 {
-    //FIXME: Using setup/teardown hooks results in a segfault
-    ecs = ecs_new(MIN_ENTITIES, NULL);
-    comp1_id = ecs_register_component(ecs, sizeof(comp_t), NULL, NULL);
-    comp2_id = ecs_register_component(ecs, sizeof(comp_t), NULL, NULL);
-
-    exclude_sys_state_t state1;
-    exclude_sys_state_t state2;
-
-    memset(&state2, 0, sizeof(exclude_sys_state_t));
     memset(&state1, 0, sizeof(exclude_sys_state_t));
+    memset(&state2, 0, sizeof(exclude_sys_state_t));
 
     ecs_id_t system1_id = ecs_register_system(ecs,
                                               exclude_system,
@@ -184,9 +179,6 @@ TEST_CASE(test_exclude)
     REQUIRE(state2.eid == eid1);
     REQUIRE(state2.add_count == 2);
     REQUIRE(state2.remove_count == 0);
-
-    ecs_free(ecs);
-    ecs = NULL;
 
     return true;
 }
@@ -797,9 +789,7 @@ TEST_CASE(test_add_remove_callbacks)
 static TEST_SUITE(suite_ecs)
 {
     RUN_TEST_CASE(test_reset);
-    pu_setup(NULL, NULL);
-    RUN_TEST_CASE(test_exclude); // FIXME: Using setup/teardown hooks results in a segfault
-    pu_setup(setup, teardown);
+    RUN_TEST_CASE(test_exclude);
     RUN_TEST_CASE(test_constructor);
     RUN_TEST_CASE(test_destructor_remove);
     RUN_TEST_CASE(test_destructor_destroy);

--- a/tests_pico_ecs/main.c
+++ b/tests_pico_ecs/main.c
@@ -25,7 +25,6 @@ typedef struct
 void setup()
 {
     ecs = ecs_new(MIN_ENTITIES, NULL);
-
     comp1_id = ecs_register_component(ecs, sizeof(comp_t), NULL, NULL);
     comp2_id = ecs_register_component(ecs, sizeof(comp_t), NULL, NULL);
 }
@@ -107,11 +106,16 @@ static void exclude_remove_cb(ecs_t* ecs,
 
 TEST_CASE(test_exclude)
 {
+    //FIXME: Using setup/teardown hooks results in a segfault
+    ecs = ecs_new(MIN_ENTITIES, NULL);
+    comp1_id = ecs_register_component(ecs, sizeof(comp_t), NULL, NULL);
+    comp2_id = ecs_register_component(ecs, sizeof(comp_t), NULL, NULL);
+
     exclude_sys_state_t state1;
     exclude_sys_state_t state2;
 
-    memset(&state1, 0, sizeof state1);
-    memset(&state2, 0, sizeof state2);
+    memset(&state2, 0, sizeof(exclude_sys_state_t));
+    memset(&state1, 0, sizeof(exclude_sys_state_t));
 
     ecs_id_t system1_id = ecs_register_system(ecs,
                                               exclude_system,
@@ -180,6 +184,9 @@ TEST_CASE(test_exclude)
     REQUIRE(state2.eid == eid1);
     REQUIRE(state2.add_count == 2);
     REQUIRE(state2.remove_count == 0);
+
+    ecs_free(ecs);
+    ecs = NULL;
 
     return true;
 }
@@ -790,7 +797,9 @@ TEST_CASE(test_add_remove_callbacks)
 static TEST_SUITE(suite_ecs)
 {
     RUN_TEST_CASE(test_reset);
-    RUN_TEST_CASE(test_exclude);
+    pu_setup(NULL, NULL);
+    RUN_TEST_CASE(test_exclude); // FIXME: Using setup/teardown hooks results in a segfault
+    pu_setup(setup, teardown);
     RUN_TEST_CASE(test_constructor);
     RUN_TEST_CASE(test_destructor_remove);
     RUN_TEST_CASE(test_destructor_destroy);


### PR DESCRIPTION
This PR intends to replace a hasty fix to prevent crashing (segfault) after `ecs_destroy`. The proper solution uses the entity system test (`ecs_entity_system_test`) instead of checking if `exclude_bits` is zero. For some inexplicable reason the `test_exclude` test case is crashing. It is necessary to create the ECS instance in the body of the test case, instead of using the setup/teardown hooks. Obviously this is suboptimal and wrong. Although I want to push the fix to `ecs_destroy` as soon as possible, I want to resolve the unit testing problem since this could be evidence of a deeper, underlying issue.