### PR TITLE
Get the component directly

### DIFF
--- a/pico_ecs.h
+++ b/pico_ecs.h
@@ -1158,7 +1158,10 @@ static void ecs_destruct(ecs_t* ecs, ecs_id_t entity_id)
 
             if (comp->destructor)
             {
-                void* ptr = ecs_get(ecs, entity_id, comp_id);
+                // Get component pointer directly without ecs_get to avoid
+                // ready assertion, since entity may be queued for destruction
+                ecs_array_t* comp_array = &ecs->comp_arrays[comp_id];
+                void* ptr = (char*)comp_array->data + (comp_array->size * entity_id);
                 comp->destructor(ecs, entity_id, ptr);
             }
         }


### PR DESCRIPTION
This avoids the issue of the entity being marked as not ready (to be destructed), and ecs_get failing the assertion on that entity being ready in order to fetch the component.