### PR TITLE
Support format strings in REQUIRE, print errors to stderr, add pu_quiet

### DIFF
--- a/examples_pico_unit/Makefile
+++ b/examples_pico_unit/Makefile
@@ -8,7 +8,7 @@ endif
 
 DEPS   = ../pico_unit.h
 
-all: example1 example2
+all: example1 example2 example3
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS)
@@ -19,7 +19,10 @@ example1: example1.o $(DEPS)
 example2: example2.o $(DEPS)
 	$(CC) -o example2 example2.o
 
+example3: example3.o $(DEPS)
+	$(CC) -o example3 example3.o
+
 .PHONY: clean
 
 clean:
-	rm -f example1 example2 *.o
+	rm -f example1 example2 example3 *.o

--- a/examples_pico_unit/example2.c
+++ b/examples_pico_unit/example2.c
@@ -66,14 +66,6 @@ TEST_CASE(test_failing2)
     return true;
 }
 
-/* A test containing a failed assertion with a formatted message. */
-TEST_CASE(test_failing3_with_message)
-{
-    REQUIRE((g_fix % 2) == 1, "Expected value %d to be odd", g_fix); /* Fails here */
-
-    return true;
-}
-
 /* A test suite containing two passing and one failing test. */
 static void
 test_suite1 ()
@@ -87,18 +79,13 @@ test_suite1 ()
     pu_clear_setup();
 }
 
-/* A test suite containing two passing and two failing tests. */
+/* A test suite containing two passing and one failing tests. */
 static void
 test_suite2 ()
 {
-    pu_setup(test_setup, test_teardown);
-    
     RUN_TEST_CASE(test_passing1);
     RUN_TEST_CASE(test_failing2);
     RUN_TEST_CASE(test_passing1);
-    RUN_TEST_CASE(test_failing3_with_message);
-    
-    pu_clear_setup();
 }
 
 /* Run all test suites and print test statistics. */

--- a/examples_pico_unit/example2.c
+++ b/examples_pico_unit/example2.c
@@ -66,6 +66,14 @@ TEST_CASE(test_failing2)
     return true;
 }
 
+/* A test containing a failed assertion with a formatted message. */
+TEST_CASE(test_failing3_with_message)
+{
+    REQUIRE((g_fix % 2) == 1, "Expected value %d to be odd", g_fix); /* Fails here */
+
+    return true;
+}
+
 /* A test suite containing two passing and one failing test. */
 static void
 test_suite1 ()
@@ -79,13 +87,14 @@ test_suite1 ()
     pu_clear_setup();
 }
 
-/* A test suite containing two passing and one failing test. */
+/* A test suite containing two passing and two failing tests. */
 static void
 test_suite2 ()
 {
     RUN_TEST_CASE(test_passing1);
     RUN_TEST_CASE(test_failing2);
     RUN_TEST_CASE(test_passing1);
+    RUN_TEST_CASE(test_failing3_with_message);
 }
 
 /* Run all test suites and print test statistics. */

--- a/examples_pico_unit/example2.c
+++ b/examples_pico_unit/example2.c
@@ -91,10 +91,14 @@ test_suite1 ()
 static void
 test_suite2 ()
 {
+    pu_setup(test_setup, test_teardown);
+    
     RUN_TEST_CASE(test_passing1);
     RUN_TEST_CASE(test_failing2);
     RUN_TEST_CASE(test_passing1);
     RUN_TEST_CASE(test_failing3_with_message);
+    
+    pu_clear_setup();
 }
 
 /* Run all test suites and print test statistics. */

--- a/examples_pico_unit/example3.c
+++ b/examples_pico_unit/example3.c
@@ -1,0 +1,90 @@
+#define PICO_UNIT_IMPLEMENTATION
+#include "../pico_unit.h"
+
+/* Sets up fixture for (called before test). */
+static void
+test_setup ()
+{
+    g_fix = 42;
+}
+
+/* Resets fixture (called after test). */
+static void
+test_teardown ()
+{
+    g_fix = 0;
+}
+
+/* All assertions pass in this test. */
+TEST_CASE(test_passing1)
+{
+    REQUIRE(1);
+    REQUIRE(42 == 42);
+    REQUIRE(str_eq("towel", "towel"));
+
+    return true;
+}
+
+/*
+ * All assertions pass in this test. Checks the value of the fixture initialized
+ * in the test setup function.
+ */
+TEST_CASE(test_passing2)
+{
+    REQUIRE(42 == g_fix);
+    REQUIRE(str_eq("frog", "frog"));
+
+    return true;
+}
+
+/* Test containing failing assertion. */
+TEST_CASE(test_failing1)
+{
+    REQUIRE(1);
+    REQUIRE(24 == 42); /* Fails here */
+    REQUIRE(1);        /* Never called */
+
+    return true;
+}
+
+/* Another test containing a failed assertion. */
+TEST_CASE(test_failing2)
+{
+    REQUIRE(str_eq("frog", "butterfly")); /* Fails here */
+    REQUIRE(true);                        /* Never called */
+
+    return true;
+}
+
+/* A test containing a failed assertion with a formatted message. */
+TEST_CASE(test_failing3_with_message)
+{
+    REQUIRE((g_fix % 2) == 1, "Expected value %d to be odd", g_fix); /* Fails here */
+
+    return true;
+}
+
+/* A test suite containing two passing and three failing tests. */
+static void
+test_suite1 ()
+{
+    pu_setup(test_setup, test_teardown);
+    RUN_TEST_CASE(test_passing1);
+    RUN_TEST_CASE(test_passing2);
+    RUN_TEST_CASE(test_failing1);
+    RUN_TEST_CASE(test_failing2);
+    RUN_TEST_CASE(test_failing3_with_message);
+    pu_clear_setup();
+}
+
+/* Run all test suites in quiet mode */
+int
+main ()
+{
+    pu_display_quiet(true); /* optional: only print failures. No stats or passing tests */
+    RUN_TEST_SUITE(test_suite1);
+    pu_print_stats(); /* prints nothing when quiet mode is enabled */
+    return 0;
+}
+
+/* EoF */

--- a/examples_pico_unit/example3.c
+++ b/examples_pico_unit/example3.c
@@ -1,6 +1,16 @@
 #define PICO_UNIT_IMPLEMENTATION
 #include "../pico_unit.h"
 
+/*
+ * Used to extend REQUIRE
+ */
+static bool str_eq(const char* str1, const char* str2)
+{
+    return 0 == strcmp(str1, str2);
+}
+
+static unsigned g_fix = 0;
+
 /* Sets up fixture for (called before test). */
 static void
 test_setup ()
@@ -56,15 +66,7 @@ TEST_CASE(test_failing2)
     return true;
 }
 
-/* A test containing a failed assertion with a formatted message. */
-TEST_CASE(test_failing3_with_message)
-{
-    REQUIRE((g_fix % 2) == 1, "Expected value %d to be odd", g_fix); /* Fails here */
-
-    return true;
-}
-
-/* A test suite containing two passing and three failing tests. */
+/* A test suite containing two passing and two failing tests. */
 static void
 test_suite1 ()
 {
@@ -73,7 +75,6 @@ test_suite1 ()
     RUN_TEST_CASE(test_passing2);
     RUN_TEST_CASE(test_failing1);
     RUN_TEST_CASE(test_failing2);
-    RUN_TEST_CASE(test_failing3_with_message);
     pu_clear_setup();
 }
 

--- a/pico_unit.h
+++ b/pico_unit.h
@@ -86,12 +86,11 @@ extern "C" {
  * message is displayed.
  *
  * @param expr The expression to evaluate
- * @param optional printf-style format string and args for failure note
  */
-#define REQUIRE(expr, ...) \
+#define REQUIRE(expr) \
     do { \
         if (!pu_require((expr) ? true : false, (#expr), __FILE__, __LINE__, \
-                        ##__VA_ARGS__, NULL)) \
+                        NULL)) \
             return false; \
     } while(false)
 
@@ -233,12 +232,12 @@ static bool     pu_quiet        = false;
 static pu_setup_fn pu_setup_fp    = NULL;
 static pu_setup_fn pu_teardown_fp = NULL;
 
-#define pu_quiet_printf(fmt, ...)                   \
-    do {                                            \
-        if (!pu_quiet)                              \
-        {                                           \
-            printf(fmt __VA_OPT__(,) __VA_ARGS__); \
-        }                                           \
+#define pu_quiet_printf(...)      \
+    do {                          \
+        if (!pu_quiet)            \
+        {                         \
+            printf(__VA_ARGS__);  \
+        }                         \
     } while(0)
 
 void

--- a/pico_unit.h
+++ b/pico_unit.h
@@ -91,7 +91,7 @@ extern "C" {
 #define REQUIRE(expr, ...) \
     do { \
         if (!pu_require((expr) ? true : false, (#expr), __FILE__, __LINE__, \
-                        __VA_OPT__(__VA_ARGS__,) NULL)) \
+                        ##__VA_ARGS__, NULL)) \
             return false; \
     } while(false)
 


### PR DESCRIPTION
- Support format strings in `REQUIRE`
- Print errors to stderr so you can filter failures to your desired output
- Add pu_quiet so you only see errors. Added bonus that it won't pollute llm context